### PR TITLE
Correct a more complete set of agency colors

### DIFF
--- a/src/maple/gtfs_handlers/colour_correction.rs
+++ b/src/maple/gtfs_handlers/colour_correction.rs
@@ -77,8 +77,8 @@ pub fn fix_background_colour_rgb_feed_route(
             "227" => RGB::new(123, 194, 77),
             "510" => RGB::new(0, 112, 191),
             "520" => RGB::new(255, 143, 0),
-            "530" => RGB::new(0, 171, 70)
-            _ => fix_background_colour_rgb(background.clone()),
+            "530" => RGB::new(0, 171, 70),
+            _ => RGB::new(233, 128, 130),
         },
         "f-c23-metrokingcounty" =>  match route.id.as_str() {
             // RapidRide Red

--- a/src/maple/gtfs_handlers/colour_correction.rs
+++ b/src/maple/gtfs_handlers/colour_correction.rs
@@ -80,9 +80,9 @@ pub fn fix_background_colour_rgb_feed_route(
             "530" => RGB::new(0, 171, 70),
             _ => RGB::new(233, 128, 130),
         },
-        "f-c23-metrokingcounty" =>  match route.route_short_name.as_str() {
+        "f-c23-metrokingcounty" =>  match route.short_name.as_deref() {
             // RapidRide Red
-            "A Line" | "B Line" | "C Line" | "D Line" | "E Line" | "F Line" | "H Line" => RGB::new(180, 10, 54),
+            Some("A Line" | "B Line" | "C Line" | "D Line" | "E Line" | "F Line" | "H Line") => RGB::new(180, 10, 54),
             // Override default region-wide blue to separate from ST Express
             _ => RGB::new(41, 133, 107),
         },

--- a/src/maple/gtfs_handlers/colour_correction.rs
+++ b/src/maple/gtfs_handlers/colour_correction.rs
@@ -75,7 +75,23 @@ pub fn fix_background_colour_rgb_feed_route(
             "215" => RGB::new(59, 192, 225),
             "225" => RGB::new(41, 52, 144),
             "227" => RGB::new(123, 194, 77),
+            "510" => RGB::new(0, 112, 191),
+            "520" => RGB::new(255, 143, 0),
+            "530" => RGB::new(0, 171, 70)
             _ => fix_background_colour_rgb(background.clone()),
+        },
+        "f-c23-metrokingcounty" =>  match route.id.as_str() {
+            // RapidRide Red
+            "100512" => RGB::new(150, 23, 46),
+            "102548" => RGB::new(150, 23, 46),
+            "102576" => RGB::new(150, 23, 46),
+            "102581" => RGB::new(150, 23, 46),
+            "102615" => RGB::new(150, 23, 46),
+            "102619" => RGB::new(150, 23, 46),
+            "102736" => RGB::new(150, 23, 46),
+            "102745" => RGB::new(150, 23, 46),
+            // Override default region-wide blue to separate from ST Express
+            _ => RGB::new(41, 133, 107),
         },
         _ => fix_background_colour_rgb(background.clone()),
     }

--- a/src/maple/gtfs_handlers/colour_correction.rs
+++ b/src/maple/gtfs_handlers/colour_correction.rs
@@ -80,16 +80,9 @@ pub fn fix_background_colour_rgb_feed_route(
             "530" => RGB::new(0, 171, 70),
             _ => RGB::new(233, 128, 130),
         },
-        "f-c23-metrokingcounty" =>  match route.id.as_str() {
+        "f-c23-metrokingcounty" =>  match route.route_short_name.as_str() {
             // RapidRide Red
-            "100512" => RGB::new(150, 23, 46),
-            "102548" => RGB::new(150, 23, 46),
-            "102576" => RGB::new(150, 23, 46),
-            "102581" => RGB::new(150, 23, 46),
-            "102615" => RGB::new(150, 23, 46),
-            "102619" => RGB::new(150, 23, 46),
-            "102736" => RGB::new(150, 23, 46),
-            "102745" => RGB::new(150, 23, 46),
+            "A Line" | "B Line" | "C Line" | "D Line" | "E Line" | "F Line" | "H Line" => RGB::new(180, 10, 54),
             // Override default region-wide blue to separate from ST Express
             _ => RGB::new(41, 133, 107),
         },


### PR DESCRIPTION
As requested by [@]sdrx902 on Twitter/X, King County Metro's RapidRide is now the correct dark red color. This commit also sets the default color for KCM routes to a green that aligns with the KCM brand - as opposed to the default blue that seems to be used across Puget Sound transit providers.

Also includes corrections for San Diego MTS lines - where GTFS includes horribly wrong colors for Trolley lines. These have been replaced by the correct colors taken directly from MTS' schedule page. Bus lines now use a light red default color instead of the dark blue the GTFS provides, which was difficult to see in dark mode and can cause rider confusion with Rapid 225, which actually does use dark blue as its color on the Rapid map. In fact, several other transit apps already manually correct MTS line colors, including [the app from Montreal] and Apple Maps (although they use an indescribable light pink for some reason)