### PR TITLE
Adding Dresden as a new GTFS RT Feed

### DIFF
--- a/src/alpenrose/custom_rt_feeds/mod.rs
+++ b/src/alpenrose/custom_rt_feeds/mod.rs
@@ -2,6 +2,7 @@ pub mod amtrak;
 //pub mod anteater_express;
 pub mod chicagotransit;
 pub mod mta;
+pub mod tlms;
 pub mod uci;
 pub mod uk;
 pub mod viarail;

--- a/src/alpenrose/custom_rt_feeds/tlms.rs
+++ b/src/alpenrose/custom_rt_feeds/tlms.rs
@@ -1,0 +1,80 @@
+use catenary::duration_since_unix_epoch;
+use catenary::get_node_for_realtime_feed_id;
+use gtfs_realtime::FeedMessage;
+use prost::Message;
+
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct DresdenResults {
+    pub vehicle_positions: FeedMessage,
+    pub trip_updates: FeedMessage,
+}
+
+pub async fn fetch_tlms_data(
+    etcd: &mut etcd_client::Client,
+    feed_id: &str,
+    client: &reqwest::Client,
+) {
+    let fetch_assigned_node_meta = get_node_for_realtime_feed_id(etcd, feed_id).await;
+
+    if let Some(worker_metadata) = fetch_assigned_node_meta {
+        let worker_id = worker_metadata.worker_id;
+
+        // the 0 meaning region 0 aka dresden
+        if let Ok(dresden_rt_data) = match client
+            .get("https://lizard.tlm.solutions/v1/gtfs/0")
+            .send()
+            .await
+        {
+            Ok(response) => response.json::<DresdenResults>(),
+            Err(e) => {
+                eprintln!("Failed to fetch Dresden Transit data");
+                eprintln!("{:?}", e);
+                return;
+            }
+        }
+        .await
+        {
+            let aspen_client =
+                catenary::aspen::lib::spawn_aspen_client_from_ip(&worker_metadata.socket)
+                    .await
+                    .unwrap();
+
+            let tarpc_send_to_aspen = aspen_client
+                .from_alpenrose(
+                    tarpc::context::current(),
+                    worker_metadata.chateau_id.clone(),
+                    String::from(feed_id),
+                    Some(dresden_rt_data.vehicle_positions.encode_to_vec()),
+                    None,
+                    None,
+                    true,
+                    true,
+                    false,
+                    Some(200),
+                    None,
+                    None,
+                    duration_since_unix_epoch().as_millis() as u64,
+                )
+                .await;
+
+            match tarpc_send_to_aspen {
+                Ok(_) => {
+                    println!(
+                        "Successfully sent dresden data to {}, feed {} to chateau {}",
+                        worker_metadata.socket, feed_id, worker_metadata.chateau_id
+                    );
+                }
+                Err(e) => {
+                    eprintln!("{}: Error sending data to {}: {}", feed_id, worker_id, e);
+                }
+            }
+        } else {
+            eprintln!("Failed to decode gtfs data from Dresden!");
+            return;
+        }
+    } else {
+        println!("No assigned node found for Chicago Transit");
+    }
+}

--- a/src/alpenrose/single_fetch_time.rs
+++ b/src/alpenrose/single_fetch_time.rs
@@ -25,7 +25,8 @@ lazy_static! {
         "f-bus~dft~gov~uk~rt",
         "f-dp3-cta~rt",
         "f-viarail~rt",
-        "f-uc~irvine~anteater~express~rt"
+        "f-uc~irvine~anteater~express~rt",
+        "f-tlms~rt"
     ]);
 }
 
@@ -294,6 +295,9 @@ pub async fn single_fetch_time(
                         }
                         None => {}
                     },
+                    "f-tlms~rt" => {
+                        custom_rt_feeds::tlms::fetch_tlms_data(&mut etcd, feed_id, &client).await;
+                    }
                     _ => {}
                 }
             }


### PR DESCRIPTION
Hi,

in the city of [Dresden, Germany](https://en.wikipedia.org/wiki/Dresden) we have built our own monitoring system for trams and busses, which doesn't rely on the [transport company](https://en.wikipedia.org/wiki/Dresdner_Verkehrsbetriebe), but determines the position data by listening to various radio protocols.

https://map.tlm.solutions (our live map) (Dresden is UTC-2, so don't worry if you only can see a hand full of vehicles) 

I saw your project and wanted to add Dresden as a location with real-time data. So I went to one of our services and quickly designed a gtfs rt endpoint. (https://github.com/tlm-solutions/lizard/commit/5b7518ea061fe3e97c7a940adeb53949d94a89d2)
(we also have a websocket where we stream position updates). 

I looked at how other gtfs rt providers were implemented and came up with this implementation. 

Feel free to cherry-pick my commit and fix all my mistakes - I do not fully comprehend your system ...