### PR TITLE
Fix victoria transit ids

### DIFF
--- a/src/aspen/import_alpenrose.rs
+++ b/src/aspen/import_alpenrose.rs
@@ -1034,12 +1034,12 @@ pub async fn new_rt_data(
                             vehicle: vehicle_pos.vehicle.as_ref().map(|vehicle| {
                                 AspenisedVehicleDescriptor {
                                     id: match realtime_feed_id.as_str() {
-                                        "f-c28-bctransit~victoriaregionaltransitsystem~rt" =>  vehicle.id.clone().replace("313135".to_string(), "").clone(),
+                                        "f-c28-bctransit~victoriaregionaltransitsystem~rt" =>  vehicle.id.map(|x| x.as_str().replace("313135", "").to_string()),
                                         _ => vehicle.id.clone(),
                                     },
                                     label: match realtime_feed_id.as_str() {
                                         "f-trimet~rt" => vehicle.id.clone(),
-                                        "f-c28-bctransit~victoriaregionaltransitsystem~rt" =>  vehicle.label.clone().replace("313135".to_string(), "").clone(),
+                                        "f-c28-bctransit~victoriaregionaltransitsystem~rt" =>  vehicle.label.map(|x| x.as_str().replace("313135", "").to_string()),
                                         _ => vehicle.label.clone(),
                                     },
                                     license_plate: vehicle.license_plate.clone(),

--- a/src/aspen/import_alpenrose.rs
+++ b/src/aspen/import_alpenrose.rs
@@ -1034,12 +1034,12 @@ pub async fn new_rt_data(
                             vehicle: vehicle_pos.vehicle.as_ref().map(|vehicle| {
                                 AspenisedVehicleDescriptor {
                                     id: match realtime_feed_id.as_str() {
-                                        "f-c28-bctransit~victoriaregionaltransitsystem~rt" =>  vehicle.id.clone().replace("313135", "").clone(),
+                                        "f-c28-bctransit~victoriaregionaltransitsystem~rt" =>  vehicle.id.clone().replace("313135".to_string(), "").clone(),
                                         _ => vehicle.id.clone(),
                                     },
                                     label: match realtime_feed_id.as_str() {
                                         "f-trimet~rt" => vehicle.id.clone(),
-                                        "f-c28-bctransit~victoriaregionaltransitsystem~rt" =>  vehicle.label.clone().replace("313135", "").clone(),
+                                        "f-c28-bctransit~victoriaregionaltransitsystem~rt" =>  vehicle.label.clone().replace("313135".to_string(), "").clone(),
                                         _ => vehicle.label.clone(),
                                     },
                                     license_plate: vehicle.license_plate.clone(),

--- a/src/aspen/import_alpenrose.rs
+++ b/src/aspen/import_alpenrose.rs
@@ -1034,12 +1034,12 @@ pub async fn new_rt_data(
                             vehicle: vehicle_pos.vehicle.as_ref().map(|vehicle| {
                                 AspenisedVehicleDescriptor {
                                     id: match realtime_feed_id.as_str() {
-                                        "f-c28-bctransit~victoriaregionaltransitsystem~rt" =>  vehicle.id.map(|x| x.as_str().replace("313135", "").to_string()),
+                                        "f-c28-bctransit~victoriaregionaltransitsystem~rt" =>  vehicle.id.as_ref().map(|x| x.as_str().replace("313135", "").to_string()),
                                         _ => vehicle.id.clone(),
                                     },
                                     label: match realtime_feed_id.as_str() {
                                         "f-trimet~rt" => vehicle.id.clone(),
-                                        "f-c28-bctransit~victoriaregionaltransitsystem~rt" =>  vehicle.label.map(|x| x.as_str().replace("313135", "").to_string()),
+                                        "f-c28-bctransit~victoriaregionaltransitsystem~rt" =>  vehicle.label.as_ref().map(|x| x.as_str().replace("313135", "").to_string()),
                                         _ => vehicle.label.clone(),
                                     },
                                     license_plate: vehicle.license_plate.clone(),

--- a/src/aspen/import_alpenrose.rs
+++ b/src/aspen/import_alpenrose.rs
@@ -1033,9 +1033,13 @@ pub async fn new_rt_data(
                             timestamp: vehicle_pos.timestamp,
                             vehicle: vehicle_pos.vehicle.as_ref().map(|vehicle| {
                                 AspenisedVehicleDescriptor {
-                                    id: vehicle.id.clone(),
+                                    id: match realtime_feed_id.as_str() {
+                                        "f-c28-bctransit~victoriaregionaltransitsystem~rt" =>  vehicle.id.clone().replace("313135", "").clone(),
+                                        _ => vehicle.id.clone(),
+                                    },
                                     label: match realtime_feed_id.as_str() {
                                         "f-trimet~rt" => vehicle.id.clone(),
+                                        "f-c28-bctransit~victoriaregionaltransitsystem~rt" =>  vehicle.label.clone().replace("313135", "").clone(),
                                         _ => vehicle.label.clone(),
                                     },
                                     license_plate: vehicle.license_plate.clone(),


### PR DESCRIPTION
Remove the prefix 313135 from Vehicle IDs of Victoria Transit in British Columbia 
Supprimer le préfixe 313135 des identifiants de véhicules de Victoria Transit en Colombie-Britannique